### PR TITLE
Avoid importing UI components when running in headless environment

### DIFF
--- a/sigkit/__init__.py
+++ b/sigkit/__init__.py
@@ -1,4 +1,3 @@
-import binaryninjaui
 from binaryninja import *
 
 # exports
@@ -9,6 +8,9 @@ from . import sig_serialize_json
 from .signaturelibrary import TrieNode, FunctionNode, Pattern, MaskedByte, new_trie
 from .compute_sig import process_function as generate_function_signature
 from .sigexplorer import explore_signature_library
+
+if core_ui_enabled():
+	import binaryninjaui
 
 def signature_explorer(prompt=True):
 	"""


### PR DESCRIPTION
Attempting to import the `binaryninjaui` module can cause the following error when running a headless version of Binary Ninja:

```
Traceback (most recent call last):
  File "/root/.binaryninja/plugins/sigkit/__init__.py", line 23, in <module>
    from .sigkit.sig_serialize_fb import SignatureLibraryReader, SignatureLibraryWriter
  File "/root/.binaryninja/plugins/sigkit/sigkit/__init__.py", line 1, in <module>
    import binaryninjaui
ModuleNotFoundError: No module named 'binaryninjaui'
```