### PR TITLE
Fix issue serializing FunctionNode objects

### DIFF
--- a/sigkit/signaturelibrary.py
+++ b/sigkit/signaturelibrary.py
@@ -283,7 +283,7 @@ class FunctionNode(object):
 		self.pattern = Pattern(b'', [])
 		self.pattern_offset = 0
 
-		self.callees = None
+		self.callees = {}
 		"""Forms a callgraph with other `FunctionNodes`. Dict of {call_offset: destination}."""
 
 		self.ref_count = 0


### PR DESCRIPTION
The following code in `sig_serialize_json.py` is used to enumerate `FunctionNode` objects in a `TrieNode` and map them to unique IDs:
```
	func_nodes = []
	func_node_ids = {None: -1}
	def visit(func_node):
		if func_node in func_node_ids: return
		func_node_ids[func_node] = len(func_nodes)
		func_nodes.append(func_node)
		for f in func_node.callees.values(): visit(f)
	for f in sig_trie.all_values(): visit(f)
```

since `FunctionNode` initializes `callees` to `None` rather than an empty dictionary, calling `func_node.callees.values()` will throw an error on any nodes which haven't explicitly added callees.