### PR TITLE
Fix for crash in case that a function was not analyzed due to its size

### DIFF
--- a/sigkit/__init__.py
+++ b/sigkit/__init__.py
@@ -52,8 +52,10 @@ if core_ui_enabled():
 		for func in bv.functions:
 			if bv.get_symbol_at(func.start) is None: continue
 			func_node, info = generate_function_signature(func, guess_relocs)
-			funcs[func_node] = info
-			log.log_debug('Processed ' + func.name)
+			if func_node and info:
+				funcs[func_node] = info
+				log.log_debug('Processed ' + func.name)
+			
 
 		log.log_debug('Constructing signature trie')
 		trie = signaturelibrary.new_trie()

--- a/sigkit/compute_sig.py
+++ b/sigkit/compute_sig.py
@@ -66,7 +66,13 @@ def guess_relocations_mask(func, sig_length):
 			i += 1
 			continue
 		for insn_len in bb._instLengths:
-			llil = func.get_low_level_il_at(func.start + i, bb.arch)
+			# This throws excpetion for large functiosn where you need to manaully force analysis
+			try:
+				llil = func.get_low_level_il_at(func.start + i, bb.arch)
+			except exceptions.ILException:
+				log_warn(f"Skipping function at {hex(func.start)}. You need to force the analysis of this function.")
+				return None
+
 			insn_mask = not is_llil_relocatable(llil)
 			# if not insn_mask:
 			#     func.set_auto_instr_highlight(func.start + i, HighlightStandardColor.BlueHighlightColor)
@@ -202,6 +208,8 @@ def function_pattern(func, guess_relocs, sig_length=None):
 		mask = guess_relocations_mask(func, sig_length)
 	else:
 		mask = relocations_mask(func, sig_length)
+	if not mask:
+		return None
 	mask = list(map(int, mask)) # bool to int
 	data = b''
 	i = 0
@@ -237,7 +245,10 @@ def process_function(func, guess_relocs):
 	func_node.source_binary = func.view.file.filename
 
 	info = signaturelibrary.FunctionInfo()
-	info.patterns = [function_pattern(func, guess_relocs)]
+	function_pattern_val = function_pattern(func, guess_relocs)
+	if not function_pattern_val:
+		return None, None
+	info.patterns = [function_pattern_val]
 	info.callees = compute_callees(func)
 	if hasattr(func.symbol, 'aliases'):
 		info.aliases = list(map(lambda s: s.decode('utf-8'), func.symbol.aliases))

--- a/sigkit/compute_sig.py
+++ b/sigkit/compute_sig.py
@@ -66,7 +66,7 @@ def guess_relocations_mask(func, sig_length):
 			i += 1
 			continue
 		for insn_len in bb._instLengths:
-			# This throws excpetion for large functiosn where you need to manaully force analysis
+			# This throws an exception for large functions where you need to manually force analysis
 			try:
 				llil = func.get_low_level_il_at(func.start + i, bb.arch)
 			except exceptions.ILException:


### PR DESCRIPTION
The plugin just returns `None` in case that there is no IL generated. I have preferred this option since I have encountered functions that took more than one hour to analyze so the assumed workflow is to log the fact that the function was skipped and let the user decided whether they force-analyze this and regenerate signatures or not rather than trigger analysis by the plugin automatically.